### PR TITLE
Add a convenient way to override default configurations

### DIFF
--- a/neuro_data/pipeline_management/NeuroDataPipelineManagement.py
+++ b/neuro_data/pipeline_management/NeuroDataPipelineManagement.py
@@ -11,7 +11,8 @@ pipeline_stimulus = dj.create_virtual_module('pipeline_stimulus', 'pipeline_stim
 PREPROC_ID = 0
 
 class NeuroDataPipelineManagement():
-    def __init__(self):
+    def __init__(self, preproc_id=PREPROC_ID):
+        self.preproc_id = preproc_id
         pass
 
     @staticmethod
@@ -48,8 +49,7 @@ class NeuroDataPipelineManagement():
             neuron_unit_key['layer'] = layer
             pipeline_anatomy.LayerMembership().insert1(neuron_unit_key, allow_direct_insert=True)
 
-    @staticmethod
-    def process_static_scans(target_scans):
+    def process_static_scans(self, target_scans):
         """
         Function that goes and check for every table that needs to be populate as well as provide an option
         to manaully populate AreaMembership and LayerMembership, assuming that all the neurons can be label the same Area and Layer
@@ -159,11 +159,11 @@ class NeuroDataPipelineManagement():
             
             # Populate Frame
             print("[NeuroData.Static Populate]: Populating Frame:")
-            Frame.populate(dict(preproc_id = PREPROC_ID), ConditionTier & target_scan)
+            Frame.populate(dict(preproc_id = self.preproc_id), ConditionTier & target_scan)
 
             # Populate InputResponse
             print("[NeuroData.Static Populate]: Populating InputResponse:")
-            InputResponse().populate(target_scan_done_key, dict(preproc_id = PREPROC_ID))
+            InputResponse().populate(target_scan_done_key, dict(preproc_id = self.preproc_id))
 
             # Populate Eye
             print("[NeuroData.Static Populate]: Populating Eye:")
@@ -175,7 +175,7 @@ class NeuroDataPipelineManagement():
 
             # Insert Scan into StaticMultiDatasetGroupAssignment with whatever is the next highest_group_id
             print("[NeuroData.Static Populate]: Inserting Scan into StaticMultiDatasetGroupAssignment with next largest group_id:")
-            target_input_response_key = (InputResponse & target_scan & dict(preproc_id=PREPROC_ID)).fetch1('KEY')
+            target_input_response_key = (InputResponse & target_scan & dict(preproc_id=self.preproc_id)).fetch1('KEY')
             if StaticMultiDatasetGroupAssignment & target_input_response_key:
                 print("[NeuroData.Static Populate]: Scan is already in StaticMultiDatasetGroupAssignment, skipping")
             else:
@@ -188,7 +188,7 @@ class NeuroDataPipelineManagement():
             StaticMultiDataset().fill()
 
             print('[NeuroData.Static Populate]: Generating HDF5 File')
-            InputResponse().get_filename(dict(**target_scan, preproc_id = PREPROC_ID))
+            InputResponse().get_filename(dict(**target_scan, preproc_id = self.preproc_id))
 
             print('[PROCESSING COMPLETED FOR SCAN: ' + str(target_scan) + ']\n')
 


### PR DESCRIPTION
Implement an option to easily override default `preproc_id`. The only way to do this previously is to change the source code.
You can now start the table population with:
```
from neuro_data.pipeline_management import NeuroDataPipelineManagement
manager = NeuroDataPipelineManagement.NeuroDataPipelineManagement(preproc_id=YourFavouritePreprocID)
manager.process_static_scans(scan_key)
```