### PR TITLE
Dynamic static model pipeline bug fixes and new part table implementation for center surround dynamic static chain

### DIFF
--- a/neuro_data/static_images/configs.py
+++ b/neuro_data/static_images/configs.py
@@ -420,14 +420,19 @@ class DataConfig(ConfigBase, dj.Lookup):
 
         @property
         def content(self):
-            for p in product(['all'],
-                             ['stimulus.Frame', '~stimulus.Frame', 'stimulus.ColorFrameProjector'],
-                             ['images,responses', ''],
-                             [True],
-                             [True, False],
-                             ['L4', 'L2/3', 'L6'],
-                             ['V1', 'LM']):
-                yield dict(zip(self.heading.dependent_attributes, p))
+            for p in [
+                *product(
+                    ["all"],
+                    ["stimulus.Frame", "~stimulus.Frame", "stimulus.ColorFrameProjector"],
+                    ["images,responses", ""],
+                    [True],
+                    [True, False],
+                    ["L4", "L2/3", "L6"],
+                    ["V1", "LM"],
+                ),
+                ["all", "stimulus.Frame2", "", True, False, "L2/3", "V1"],
+            ]:
+                yield dict(zip(self.heading.secondary_attributes, p))
 
     class ModeledAreaLayer(dj.Part, AreaLayerModelMixin):
         definition = """
@@ -441,7 +446,7 @@ class DataConfig(ConfigBase, dj.Lookup):
             for p in [
                 (0,)
             ]:
-                yield dict(zip(self.heading.dependent_attributes, p))
+                yield dict(zip(self.heading.secondary_attributes, p))
 
     class MultipleAreasOneLayer(dj.Part, AreaLayerRawMixin):
         definition = """
@@ -468,7 +473,7 @@ class DataConfig(ConfigBase, dj.Lookup):
                              [True, False],
                              ['L4', 'L2/3'],
                              ['all-unknown', 'all']):
-                yield dict(zip(self.heading.dependent_attributes, p))
+                yield dict(zip(self.heading.secondary_attributes, p))
 
     class MultipleAreasMultipleLayers(dj.Part, AreaLayerRawMixin):
         definition = """
@@ -495,7 +500,7 @@ class DataConfig(ConfigBase, dj.Lookup):
                              [True, False],
                              ['all-unset', 'all'],
                              ['all-unknown', 'all']):
-                yield dict(zip(self.heading.dependent_attributes, p))
+                yield dict(zip(self.heading.secondary_attributes, p))
 
     ############ Below are data configs that were using the buggy normalizer #################
     class AreaLayer(dj.Part, BackwardCompatibilityMixin, AreaLayerRawMixin):
@@ -522,7 +527,7 @@ class DataConfig(ConfigBase, dj.Lookup):
                              [True],
                              ['L4', 'L2/3'],
                              ['V1', 'LM']):
-                yield dict(zip(self.heading.dependent_attributes, p))
+                yield dict(zip(self.heading.secondary_attributes, p))
 
     class AreaLayerPercentOracle(dj.Part, BackwardCompatibilityMixin, AreaLayerRawMixin):
         definition = """
@@ -563,7 +568,7 @@ class DataConfig(ConfigBase, dj.Lookup):
                              ['V1'],
                              [25],
                              [75]):
-                yield dict(zip(self.heading.dependent_attributes, p))
+                yield dict(zip(self.heading.secondary_attributes, p))
             for p in product(['all'],
                              ['stimulus.Frame', '~stimulus.Frame'],
                              ['images,responses'],
@@ -573,7 +578,7 @@ class DataConfig(ConfigBase, dj.Lookup):
                              ['V1'],
                              [75],
                              [100]):
-                yield dict(zip(self.heading.dependent_attributes, p))
+                yield dict(zip(self.heading.secondary_attributes, p))
             for p in product(['all'],
                              ['stimulus.Frame', '~stimulus.Frame'],
                              ['images,responses'],
@@ -583,7 +588,7 @@ class DataConfig(ConfigBase, dj.Lookup):
                              ['V1'],
                              [0],
                              [100]):
-                yield dict(zip(self.heading.dependent_attributes, p))
+                yield dict(zip(self.heading.secondary_attributes, p))
 
         def load_data(self, key, tier=None, batch_size=1, key_order=None, stimulus_types=None, Sampler=None):
             from .stats import Oracle
@@ -647,7 +652,7 @@ class DataConfig(ConfigBase, dj.Lookup):
                              [0.2],
                              ['L2/3'],
                              ['V1']):
-                yield dict(zip(self.heading.dependent_attributes, p))
+                yield dict(zip(self.heading.secondary_attributes, p))
 
         def load_data(self, key, **kwargs):
             return super().load_data(key, balanced=False, **kwargs)
@@ -682,7 +687,7 @@ class DataConfig(ConfigBase, dj.Lookup):
                              [0.2],
                              ['L2/3'],
                              ['V1']):
-                yield dict(zip(self.heading.dependent_attributes, p))
+                yield dict(zip(self.heading.secondary_attributes, p))
 
         def load_data(self, key, **kwargs):
             return super().load_data(key, balanced=True, **kwargs)
@@ -713,7 +718,7 @@ class DataConfig(ConfigBase, dj.Lookup):
                              ['L2/3'],
                              ['V1'],
                              [-3]):
-                yield dict(zip(self.heading.dependent_attributes, p))
+                yield dict(zip(self.heading.secondary_attributes, p))
         
         def load_data(self, key, tier=None, batch_size=1,
                       Sampler=None, t_first=False, cuda=False):

--- a/neuro_data/static_images/dataset_config.py
+++ b/neuro_data/static_images/dataset_config.py
@@ -131,7 +131,9 @@ class InputConfig(ConfigBase, dj.Lookup):
             params = (self * Preprocessing).fetch1()
             if not (params["gamma"] or params["linear_mon"]):
                 trial_idx, cond, frame = (
-                    stimulus.Trial * Frame & scan_key & params  # WARNING: anything populated in Frame will be loaded, does not restrict on stimulus_type, nor check if all stimuli are processed
+                    stimulus.Trial * Frame
+                    & scan_key
+                    & params  # WARNING: anything populated in Frame will be loaded, does not restrict on stimulus_type, nor check if all stimuli are processed
                 ).fetch(
                     "trial_idx",
                     "condition_hash",
@@ -203,7 +205,6 @@ class TierConfig(ConfigBase, dj.Lookup):
             cond_df = cond_df.merge(cond_tier_df, on="condition_hash", how="left")
             assert cond_df.tier.notnull().all(), "Missing tier for some conditions!"
             return cond_df.tier.values
-
 
 
 @schema
@@ -478,7 +479,6 @@ class StatsConfig(ConfigBase, dj.Lookup):
                 how="left",
             )
             assert not info_df.isna().any().any(), "Missing stimulus info"
-
 
             # compute stats
             if key["stats_tier"] in ("train", "validation", "test"):

--- a/neuro_data/static_images/dataset_config.py
+++ b/neuro_data/static_images/dataset_config.py
@@ -7,6 +7,7 @@ from neuro_data import logger as log
 from neuro_data.static_images import datasets
 from neuro_data.utils.config import ConfigBase
 from neuro_data.utils.data import h5cached
+from neuro_data.utils.stimuli import frame2_make_mask
 
 from .data_schemas import (
     FF_CLASSES,
@@ -81,6 +82,7 @@ class InputConfig(ConfigBase, dj.Lookup):
         """
         content = [
             {"preproc_id": 9},
+            {"preproc_id": 0},
         ]
 
         def input(self, scan_key):
@@ -88,7 +90,7 @@ class InputConfig(ConfigBase, dj.Lookup):
             params = (self * Preprocessing).fetch1()
             if not (params["gamma"] or params["linear_mon"]):
                 trial_idx, cond, frame = (
-                    InputResponse.Input * Frame & stimulus.Frame & scan_key & params
+                    InputResponse.Input * Frame & scan_key & params
                 ).fetch(
                     "trial_idx",
                     "condition_hash",
@@ -116,64 +118,43 @@ class InputConfig(ConfigBase, dj.Lookup):
                 )
             return trial_idx, cond, frame, np.full(len(trial_idx), "stimulus.Frame")
 
-    # # WIP
-    # class Frame2Jk(dj.Part):
-    #     # only load stimulus_type=='stimulus.Frame2', fetch input image from Jiakun's personal InputResponse table
-    #     definition = """
-    #     -> master
-    #     ---
-    #     row             : smallint          # row size of the image
-    #     col             : smallint          # column size of the image
-    #     """
-    #     content = [
-    #         {"row": 36, "col": 64},
-    #     ]
+    class NeuroStaticFrameV2(dj.Part):
+        # only load stimulus_type=='stimulus.Frame2'
+        definition = """
+        -> master
+        ---
+        -> Preprocessing
+        """
+        content = [
+            {"preproc_id": 0},
+        ]
 
-    #     @staticmethod
-    #     def process_frame(preproc_key, frame):
-    #         """
-    #         Helper function that preprocesses a frame
-    #         """
-    #         import cv2
-
-    #         imgsize = (Preprocessing() & preproc_key).fetch1(
-    #             "col", "row"
-    #         )  # target size of movie frames
-    #         log.info("Downsampling frame")
-    #         if not frame.shape[0] / imgsize[1] == frame.shape[1] / imgsize[0]:
-    #             log.warning("Image size would change aspect ratio.")
-
-    #         return cv2.resize(frame, imgsize, interpolation=cv2.INTER_AREA).astype(
-    #             np.float32
-    #         )
-
-    #     def input(self, scan_key):
-    #         params = (self * Preprocessing).fetch1()
-    #         if not (params["gamma"] or params["linear_mon"]):
-    #             trial_idx, cond, frame = (
-    #                 InputResponse.Input * Frame & stimulus.Frame & scan_key & params
-    #             ).fetch(
-    #                 "trial_idx",
-    #                 "condition_hash",
-    #                 "frame",
-    #                 order_by="row_id",  # order by row_id to ensure the order matches Eye and Treadmill
-    #             )
-    #             valid_eye = (Eye & scan_key & params).fetch("valid")
-    #             valid_treadmill = (Treadmill & scan_key & params).fetch("valid")
-    #             valid = valid_eye & valid_treadmill
-    #             # keep only valid trials
-    #             trial_idx = trial_idx[valid]
-    #             cond = cond[valid]
-    #             frame = np.stack(frame)[valid]
-    #             # check if all frames have the same shape
-    #             assert len(frame.shape) == 3 and frame.shape[1]==params['row'] and frame.shape[2]==params['col'], 'dimension mismatch, only support 3-D frame (B,H,W)'
-    #             # adjust frame shape to (B,1,W,H)
-    #             frame = frame[:, None, ...]
-    #         else:
-    #             raise NotImplementedError(
-    #                 f'InputConfig: gamma={params["gamma"]}, linear_mon={params["linear_mon"]} not implemented!'
-    #             )
-    #         return trial_idx, cond, frame, np.full(len(trial_idx), "stimulus.Frame")
+        def input(self, scan_key):
+            params = (self * Preprocessing).fetch1()
+            if not (params["gamma"] or params["linear_mon"]):
+                trial_idx, cond, frame = (
+                    stimulus.Trial * Frame & scan_key & params  # WARNING: anything populated in Frame will be loaded, does not restrict on stimulus_type, nor check if all stimuli are processed
+                ).fetch(
+                    "trial_idx",
+                    "condition_hash",
+                    "frame",
+                    order_by="trial_idx",
+                )
+                # reshape inputs
+                frame = np.stack(frame)
+            else:
+                raise NotImplementedError(
+                    f'InputConfig: gamma={params["gamma"]}, linear_mon={params["linear_mon"]} not implemented!'
+                )
+            # check if all frames have the same shape
+            assert (
+                len(frame.shape) == 3
+                and frame.shape[1] == params["row"]
+                and frame.shape[2] == params["col"]
+            ), "dimension mismatch, only support 3-D frame (B,H,W)"
+            # adjust frame shape to (B,1,W,H)
+            frame = frame[:, None, ...]
+            return trial_idx, cond, frame, np.full(len(trial_idx), "stimulus.Frame")
 
 
 @schema
@@ -225,28 +206,28 @@ class TierConfig(ConfigBase, dj.Lookup):
             assert cond_df.tier.notnull().all(), "Missing tier for some conditions!"
             return cond_df.tier.values
 
-    # # WIP
-    # class ConditionTierJk(dj.Part):
-    #     definition = """
-    #     -> master
-    #     ---
-    #     """
-    #     content = [
-    #         {},
-    #     ]
+    class ConditionTierJk(dj.Part):
+        definition = """
+        -> master
+        ---
+        """
+        content = [
+            {},
+        ]
 
-    #     def tier(self, scan_key, condition_hashes):
-    #         cond_tier_df = pd.DataFrame(
-    #             (
-    #                 (jiakun.ConditionTier & scan_key).fetch(
-    #                     "condition_hash", "tier", as_dict=True
-    #                 )
-    #             )
-    #         )
-    #         cond_df = pd.DataFrame(dict(condition_hash=condition_hashes))
-    #         cond_df = cond_df.merge(cond_tier_df, on="condition_hash", how="left")
-    #         assert cond_df.tier.notnull().all(), "Missing tier for some conditions!"
-    #         return cond_df.tier.values
+        def tier(self, scan_key, condition_hashes):
+            cond_tier_df = pd.DataFrame(
+                (
+                    (jiakun.ConditionTier & scan_key & 'mask=2').fetch(
+                        "condition_hash", "tier", as_dict=True
+                    )
+                )
+            )
+            cond_df = pd.DataFrame(dict(condition_hash=condition_hashes))
+            cond_df = cond_df.merge(cond_tier_df, on="condition_hash", how="left")
+            assert cond_df.tier.notnull().all(), "Missing tier for some conditions!"
+            assert len(condition_hashes) == len(cond_df), "Number of condition hashes mismatch!"
+            return cond_df.tier.values
 
 
 @schema
@@ -440,130 +421,105 @@ class StatsConfig(ConfigBase, dj.Lookup):
             statistics = dict(images=input_statistics, responses=response_statistics)
             return statistics
 
-    # # WIP
-    # class NoBehFullFieldFrame2(dj.Part):
-    #     # implemented only for full field stimulus with stimulus_type=='stimulus.Frame2'
-    #     definition = """
-    #     # mimic the behavior of InputResponse with the corresponding preprocess_id to compute the statistics of input and responses, do not compute stats for behavior variables
-    #     -> master
-    #     ---
-    #     stats_tier="train"                 : enum("train", "test", "validation", "all")               # tier used for computing stats
-    #     stats_per_input                    : tinyint                                                  # whether to compute stats per input
-    #     """
-    #     content = [
-    #         dict(stats_tier="train", stats_per_input=0),
-    #     ]
+    class NoBehFullFieldFrame2(dj.Part):
+        # implemented only for full field stimulus with stimulus_type=='stimulus.Frame2'
+        definition = """
+        # mimic the behavior of InputResponse with the corresponding preprocess_id to compute the statistics of input and responses, do not compute stats for behavior variables
+        -> master
+        ---
+        stats_tier="train"                 : enum("train", "test", "validation", "all")               # tier used for computing stats
+        stats_per_input                    : tinyint                                                  # whether to compute stats per input
+        """
+        content = [
+            dict(stats_tier="train", stats_per_input=0),
+        ]
 
-    #     @staticmethod
-    #     def make_mask(x, y, r, trans, sz):  # sz is height by width
-    #         if r > 1:
-    #             return np.ones(sz)
-    #         else:
-    #             radius = r * sz[1]
-    #             transition = trans * sz[1]
-    #             x_, y_ = x, y
-    #             x = np.linspace(-sz[1] / 2, sz[1] / 2, sz[1]) - x_ * sz[0]
-    #             y = np.linspace(-sz[0] / 2, sz[0] / 2, sz[0]) - y_ * sz[0]
-    #             [X, Y] = np.meshgrid(x, y)
-    #             rr = np.sqrt(X * X + Y * Y)
-    #             fxn = lambda r: 0.5 * (1 + np.cos(np.pi * r)) * (r < 1) * (r > 0) + (
-    #                 r < 0
-    #             )
-    #             alpha_mask = fxn((rr - radius) / transition + 1)
-    #             return alpha_mask
+        @staticmethod
+        def run_stats_resp(data, ix, axis=0):
+            ret = {}
+            data = data[ix]
+            ret["all"] = dict(
+                mean=data.mean(axis=axis).astype(np.float32),
+                std=data.std(axis=axis, ddof=1).astype(np.float32),
+                min=data.min(axis=axis).astype(np.float32),
+                max=data.max(axis=axis).astype(np.float32),
+                median=np.median(data, axis=axis).astype(np.float32),
+            )
+            ret["stimulus.Frame2"] = ret["all"]
+            return ret
 
-    #     @staticmethod
-    #     def run_stats_resp(data, ix, axis=0):
-    #         ret = {}
-    #         data = data[ix]
-    #         ret["all"] = dict(
-    #             mean=data.mean(axis=axis).astype(np.float32),
-    #             std=data.std(axis=axis, ddof=1).astype(np.float32),
-    #             min=data.min(axis=axis).astype(np.float32),
-    #             max=data.max(axis=axis).astype(np.float32),
-    #             median=np.median(data, axis=axis).astype(np.float32),
-    #         )
-    #         ret["stimulus.Frame2"] = ret["all"]
-    #         return ret
+        def run_stats_input(self, data, info_df, ix, per_input):
+            if per_input:
+                raise NotImplementedError("per_input is not implemented for Frame2")
+            ret = {}
+            data = data[ix]
+            info_df = info_df.loc[ix]
+            from statsmodels.stats.weightstats import DescrStatsW as wstats
 
-    #     def run_stats_input(self, data, info_df, ix, per_input):
-    #         if per_input:
-    #             raise NotImplementedError("per_input is not implemented for Frame2")
-    #         ret = {}
-    #         data = data[ix]
-    #         info_df = info_df.loc[ix]
-    #         from statsmodels.stats.weightstats import DescrStatsW as wstats
+            sizes = [d.squeeze().shape for d in data]
+            assert len(set(sizes)) == 1, "All images must have the same size"
+            masks = [
+                frame2_make_mask(
+                    row["aperture_x"],
+                    row["aperture_y"],
+                    row["aperture_r"],
+                    row["aperture_transition"],
+                    sizes[0],
+                )
+                for _, row in info_df.iterrows()
+            ]
+            data_flat = np.hstack([d.flatten() for d in data])
+            data_mask = np.hstack([m.flatten() for m in masks])
 
-    #         sizes = [d.squeeze().shape for d in data]
-    #         assert len(np.unqiue(sizes)) == 1, "All images must have the same size"
-    #         masks = [
-    #             self.make_mask(
-    #                 row["aperture_x"],
-    #                 row["aperture_y"],
-    #                 row["aperture_r"],
-    #                 row["aperture_transition"],
-    #                 sizes[0],
-    #             )
-    #             for _, row in info_df.iterrows()
-    #         ]
-    #         data_flat = np.hstack(d.flatten() for d in data)
-    #         data_mask = np.hstack(m.flatten() for m in masks)
+            data_mean = wstats(data_flat, data_mask).mean
+            data_std = wstats(data_flat, data_mask).std
 
-    #         data_mean = wstats(data_flat, data_mask).mean
-    #         data_std = wstats(data_flat, data_mask).std
+            ret["stimulus.Frame2"] = dict(
+                mean=data_mean.astype(np.float32),
+                std=data_std.astype(np.float32),
+                min=data.min().astype(np.float32),
+                max=data.max().astype(np.float32),
+                median=np.median(data).astype(np.float32),
+            )
+            ret["all"] = ret["stimulus.Frame2"]
+            return ret
 
-    #         ret["stimulus.Frame2"] = dict(
-    #             mean=data_mean.astype(np.float32),
-    #             std=data_std.astype(np.float32),
-    #             min=data.min().astype(np.float32),
-    #             max=data.max().astype(np.float32),
-    #             median=np.median(data).astype(np.float32),
-    #         )
-    #         ret["all"] = ret["stimulus.Frame2"]
-    #         return ret
+        def stats(self, condition_hashes, images, responses, tiers):
+            assert len(images.shape) == 4, "images dimension must be [B,C,H,W]"
+            assert images.shape[1] == 1, "only support single channel images"
+            key = self.fetch1()
+            # check if the method is eligible for condition_hashes requested and collect stimulus info
+            assert (
+                (
+                    stimulus.Condition
+                    & "condition_hash in {}".format(tuple(condition_hashes))
+                ).fetch("stimulus_type")
+                == "stimulus.Frame2"
+            ).all(), "StatsConfig.NeuroStaticNoBehFrame2 is only implemented for stimulus.Frame2"
+            info_df = pd.DataFrame(dict(condition_hash=condition_hashes))
+            info_df = info_df.merge(
+                pd.DataFrame((stimulus.Frame2 & info_df).fetch(as_dict=True)),
+                how="left",
+            )
+            assert not info_df.isna().any().any(), "Missing stimulus info"
 
-    #     def stats(self, condition_hashes, images, responses, tiers):
 
-    #         key = self.fetch1()
-    #         # check if the method is eligible for condition_hashes requested and collect stimulus info
-    #         assert (
-    #             (
-    #                 stimulus.Condition
-    #                 & "condition_hash in {}".format(tuple(condition_hashes))
-    #             ).fetch("stimulus_type")
-    #             == "stimulus.Frame2"
-    #         ).all(), "StatsConfig.NeuroStaticNoBehFrame2 is only implemented for stimulus.Frame2"
-    #         info_df = pd.DataFrame(dict(condition_hash=condition_hashes))
-    #         info_df = info_df.merge(
-    #             pd.DataFrame(stimulus.Condition.Frame2 & info_df).fetch(as_dict=True),
-    #             how="left",
-    #         )
-    #         assert not info_df.isna().any()
+            # compute stats
+            if key["stats_tier"] in ("train", "validation", "test"):
+                ix = tiers == key["stats_tier"]
+            elif key["stats_tier"] == "all":
+                ix = np.ones_like(tiers, dtype=bool)
+            else:
+                raise NotImplementedError(
+                    "stats_tier must be one of train, validation, test, all"
+                )
 
-    #         # reshape inputs
-    #         images = np.stack(images)
-    #         if len(images.shape) == 3:
-    #             log.info("Adding channel dimension")
-    #             images = images[:, None, ...]
-    #         elif len(images.shape) == 4:
-    #             images = images.transpose(0, 3, 1, 2)
-
-    #         # compute stats
-    #         if key["stats_tier"] in ("train", "validation", "test"):
-    #             ix = tiers == key["stats_tier"]
-    #         elif key["stats_tier"] == "all":
-    #             ix = np.ones_like(tiers, dtype=bool)
-    #         else:
-    #             raise NotImplementedError(
-    #                 "stats_tier must be one of train, validation, test, all"
-    #             )
-
-    #         response_statistics = self.run_stats_resp(responses, ix, axis=0)
-    #         input_statistics = self.run_stats_input(
-    #             images, info_df, ix, per_input=key["stats_per_input"]
-    #         )
-    #         statistics = dict(images=input_statistics, responses=response_statistics)
-    #         return statistics
+            response_statistics = self.run_stats_resp(responses, ix, axis=0)
+            input_statistics = self.run_stats_input(
+                images, info_df, ix, per_input=key["stats_per_input"]
+            )
+            statistics = dict(images=input_statistics, responses=response_statistics)
+            return statistics
 
 
 @schema
@@ -641,16 +597,25 @@ class DatasetConfig(ConfigBase, dj.Lookup):
                     "scan_idx": key["static_scan_idx"],
                 }
             ).fetch1("KEY")
+            dynamic_scan = (
+                DvScanInfo()
+                & {
+                    **key,
+                    "animal_id": key["animal_id"],
+                    "session": key["dynamic_session"],
+                    "scan_idx": key["dynamic_scan_idx"],
+                }
+            ).fetch1("KEY")
             log.info("Fecthing images")
             trial_idx, condition_hashes, images, types = (
                 InputConfig().part_table(key).input(static_scan)
             )
             log.info("Fetching responses")
-            responses = (DvScanInfo & key).responses(
+            responses = (DvScanInfo & dynamic_scan).responses(
                 trial_idx=trial_idx,
                 condition_hashes=condition_hashes,
             )
-            dynamic_unit_keys = (DvScanInfo & key).unit_keys()
+            dynamic_unit_keys = (DvScanInfo & dynamic_scan).unit_keys()
             log.info("Fecthing tiers")
             tiers = TierConfig().part_table(key).tier(static_scan, condition_hashes)
             log.info("Fecthing layer information")

--- a/neuro_data/static_images/dataset_config.py
+++ b/neuro_data/static_images/dataset_config.py
@@ -24,8 +24,6 @@ from .data_schemas import (
 )
 from .ds_pipe import DvScanInfo
 
-jiakun = dj.create_virtual_module("jiakun", "jiakun_model_data")
-
 
 @schema
 class InputConfig(ConfigBase, dj.Lookup):
@@ -206,28 +204,6 @@ class TierConfig(ConfigBase, dj.Lookup):
             assert cond_df.tier.notnull().all(), "Missing tier for some conditions!"
             return cond_df.tier.values
 
-    class ConditionTierJk(dj.Part):
-        definition = """
-        -> master
-        ---
-        """
-        content = [
-            {},
-        ]
-
-        def tier(self, scan_key, condition_hashes):
-            cond_tier_df = pd.DataFrame(
-                (
-                    (jiakun.ConditionTier & scan_key & 'mask=2').fetch(
-                        "condition_hash", "tier", as_dict=True
-                    )
-                )
-            )
-            cond_df = pd.DataFrame(dict(condition_hash=condition_hashes))
-            cond_df = cond_df.merge(cond_tier_df, on="condition_hash", how="left")
-            assert cond_df.tier.notnull().all(), "Missing tier for some conditions!"
-            assert len(condition_hashes) == len(cond_df), "Number of condition hashes mismatch!"
-            return cond_df.tier.values
 
 
 @schema

--- a/neuro_data/static_images/ds_pipe.py
+++ b/neuro_data/static_images/ds_pipe.py
@@ -405,7 +405,9 @@ class DvModelConfig(ConfigBase, dj.Lookup):
             )
             assert len(resp_key_df) == len(cond_df)
             response = (
-                dv_nn10_scan.ScanModelInstance * dv_nn10_resp.ScanImageResponse * dv_nn10_resp.ImageResponseConfig.Aperture()
+                dv_nn10_scan.ScanModelInstance
+                * dv_nn10_resp.ScanImageResponse
+                * dv_nn10_resp.ImageResponseConfig.Aperture()
                 & dynamic_scan
                 & self
                 & resp_key_df
@@ -483,20 +485,8 @@ class DvScanInfo(dj.Computed):
 
     @property
     def key_source(self):
-        keys = data.StaticScan * DvModelConfig
-        key = [
-            # dv_nn6_models() * DvModelConfig.Nn6 * dv_nn6_scan.Scan,
-            # dv_nn9_scan.ScanModelInstance * DvModelConfig.Nn9 * dv_nn9_scan.Scan,
-            dv_nn10_scan.ScanModelInstance
-            * DvModelConfig.Nn10
-            * dv_nn10_scan.Scan
-            ,
-            dv_nn10_scan.ScanModelInstance
-            * DvModelConfig.Nn10Frame2
-            * dv_nn10_scan.Scan
-            ,
-        ]
-        return keys & key
+        from neuro_data.static_images import requests
+        return super().key_source & requests.DvScanInfoRequest
 
     def make(self, key):
         unit_keys = DvModelConfig().part_table(key).unit_keys(key)

--- a/neuro_data/static_images/ds_pipe.py
+++ b/neuro_data/static_images/ds_pipe.py
@@ -3,6 +3,7 @@ from neuro_data.utils.config import ConfigBase
 import pandas as pd
 import numpy as np
 from neuro_data.static_images.data_schemas import StaticScan, schema, stimulus, fuse
+from neuro_data.static_images import data_schemas as data
 
 # # Archived
 # dv_nn6_architecture = dj.create_virtual_module(
@@ -50,7 +51,100 @@ dv_scan3_scan_dataset = dj.create_virtual_module(
     "dv_scan3_scan_dataset", "dv_scans_v3_scan_dataset"
 )
 dv_scan3_scan = dj.create_virtual_module("dv_scan3_scan", "dv_scans_v3_scan")
-dv_stim2_stimulus = dj.create_virtual_module('dv_stim2_stimulus', 'dv_stimuli_v2_stimulus')
+dv_stim2_stimulus = dj.create_virtual_module(
+    "dv_stim2_stimulus", "dv_stimuli_v2_stimulus"
+)
+
+
+class Nn10Mixin:
+    @property
+    def content(self):
+        return (
+            dj.U(*self.heading.secondary_attributes)
+            & (dv_nn10_scan.ScanModelInstance * dv_nn10_resp.ScanImageResponse)
+            & (  # preblank = 5 msec
+                dv_nn10_resp.ImageResponseConfig().Lowpass() & "pre_duration=5"
+            )
+            & (  # all unit & all dynamic clips
+                dv_nn10_scan.ScanConfig().Scan3()
+                & dv_scan3_scan_dataset.UnitConfig().All()
+                & (
+                    dv_scan3_scan_dataset.TrialConfig().TrainSet()
+                    & dv_stim2_stimulus.StimulusSetConfig()
+                    .AllDynamic()
+                    .proj(include_stimulus_set_hash="stimulus_set_hash")
+                    & dv_stim2_stimulus.StimulusSetConfig().OracleClip.proj(
+                        exclude_stimulus_set_hash="stimulus_set_hash"
+                    )
+                )
+            )
+        )
+
+    def unit_keys(self, dynamic_scan):
+        dynamic_scan, n_units = (dv_nn10_scan.Scan & dynamic_scan & self).fetch1(
+            dj.key, "n_units"
+        )
+        units = (
+            self
+            * dv_nn10_scan.Scan.Unit
+            * dv_nn10_scan.ScanConfig().Scan3()
+            * (
+                dv_scan3_scan_dataset.Preprocess
+                * dv_scan3_scan.ResponseId.proj(..., scan_ms_delay="ms_delay")
+            )  # recover spike_method
+            & dynamic_scan
+        )
+        unit_keys = units.fetch(
+            *(fuse.ScanDone * fuse.ScanSet.Unit).primary_key,
+            as_dict=True,
+            order_by="nn_response_index"
+        )
+
+        assert len(unit_keys) == n_units
+
+        return unit_keys
+
+    def unique_unit_mapping(self, dynamic_scan):
+        if (
+            self
+            * dv_nn10_scan.ScanConfig.Scan3()
+            * dv_scan3_scan_dataset.UnitConfig.Unique()
+        ):
+
+            key = (
+                (
+                    self
+                    * dv_nn10_scan.ScanConfig.Scan3()
+                    * dv_scan3_scan_dataset.UnitConfig.Unique()
+                )
+                & dynamic_scan
+            ).fetch1()  # get unique_id
+            unique_unit_key = (dv_scan3_scan.Unique() & dynamic_scan & key).fetch1(
+                "KEY"
+            )
+            unique_unit_rel = (
+                dv_scan3_scan.Unique.Unit
+                * dv_scan3_scan.Unique.Neuron.proj(unique_unit_id="unit_id")
+                & unique_unit_key
+            )
+            return (
+                dj.U("animal_id", "session", "scan_idx", "unit_id", "unique_unit_id")
+                & unique_unit_rel
+            )
+        elif (
+            self
+            * dv_nn10_scan.ScanConfig.Scan3()
+            * dv_scan3_scan_dataset.UnitConfig.All()
+        ):  # return a mapping from all units to themselves
+            units = self * dv_nn10_scan.Scan.Unit * dv_nn10_scan.ScanConfig().Scan3()
+            return units.proj(unique_unit_id="unit_id * 1")
+        else:
+            raise NotImplementedError(
+                "`unique_unit_mapping` is not implemented for key {}!".format(
+                    self.fetch1()
+                )
+            )
+
 
 @schema
 class DvModelConfig(ConfigBase, dj.Lookup):
@@ -175,10 +269,10 @@ class DvModelConfig(ConfigBase, dj.Lookup):
     #         ) & (  # preblank = 5 msec
     #             dv_nn9_resp.ImageResponseConfig().Lowpass() & 'pre_duration=5'
     #         ) & (  # all unit & all dynamic clips
-    #             dv_nn9_scan.ScanConfig().Scan3() 
+    #             dv_nn9_scan.ScanConfig().Scan3()
     #             & dv_scan3_scan_dataset.UnitConfig().All()
     #             & (
-    #                 dv_scan3_scan_dataset.TrialConfig().TrainSet() 
+    #                 dv_scan3_scan_dataset.TrialConfig().TrainSet()
     #                 & dv_stim2_stimulus.StimulusSetConfig().AllDynamic().proj(include_stimulus_set_hash='stimulus_set_hash')
     #                 & dv_stim2_stimulus.StimulusSetConfig().OracleClip.proj(exclude_stimulus_set_hash='stimulus_set_hash')
     #             )
@@ -192,7 +286,7 @@ class DvModelConfig(ConfigBase, dj.Lookup):
     #             * dv_nn9_scan.Scan.Unit
     #             * dv_nn9_scan.ScanConfig().Scan3()
     #             * (
-    #                 dv_scan3_scan_dataset.Preprocess 
+    #                 dv_scan3_scan_dataset.Preprocess
     #                 * dv_scan3_scan.ResponseId.proj(..., scan_ms_delay='ms_delay')
     #             )  # recover spike_method
     #             & dynamic_scan
@@ -238,7 +332,7 @@ class DvModelConfig(ConfigBase, dj.Lookup):
     #                 * dv_nn9_scan.ScanConfig.Scan3()
     #                 * dv_scan3_scan_dataset.UnitConfig.Unique()
     #             ):
-    
+
     #             key = (
     #                 (
     #                     self
@@ -276,8 +370,58 @@ class DvModelConfig(ConfigBase, dj.Lookup):
     #                     self.fetch1()
     #                 )
     #             )
-    
-    class Nn10(dj.Part):
+
+    class Nn10Frame2(Nn10Mixin, dj.Part):
+        definition = """  # process static scans with Frame2 stimuli
+        -> master
+        ---
+        -> dv_nn10_resp.ResponseDelay
+        -> dv_nn10_resp.ImageResponseConfig
+        -> dv_nn10_model.InstanceConfig
+        -> dv_nn10_model.OutputConfig
+        -> dv_nn10_scan.ScanConfig
+        -> dv_nn10_scan.NnConfig
+        """
+
+        @property
+        def content(self):
+            return super().content & dv_nn10_resp.ImageConfig.Aperture
+
+        def responses(self, dynamic_scan, trial_idx, condition_hashes):
+            assert len(trial_idx) == len(condition_hashes)
+            cond_df = pd.DataFrame({"condition_hash": condition_hashes})
+            resp_key_df = pd.DataFrame(
+                (stimulus.Frame2 & cond_df).fetch(
+                    "image_class",
+                    "image_id",
+                    "condition_hash",
+                    "aperture_x",
+                    "aperture_y",
+                    "aperture_r",
+                    "aperture_transition",
+                    "background_value",
+                    as_dict=True,
+                )
+            )
+            assert len(resp_key_df) == len(cond_df)
+            response = (
+                dv_nn10_scan.ScanModelInstance * dv_nn10_resp.ScanImageResponse * dv_nn10_resp.ImageResponseConfig.Aperture()
+                & dynamic_scan
+                & self
+                & resp_key_df
+            )
+            resp_df = pd.DataFrame(
+                (response & resp_key_df).fetch(
+                    "image_class", "image_id", "response", as_dict=True
+                )
+            )
+            resp_df = cond_df.merge(
+                resp_key_df.merge(resp_df, how="left"), how="left", validate="m:1"
+            )
+            assert len(cond_df) == len(resp_df)
+            return np.stack(resp_df.response.values)  # (n_images, n_units)
+
+    class Nn10(Nn10Mixin, dj.Part):
         definition = """
         -> master
         ---
@@ -292,42 +436,7 @@ class DvModelConfig(ConfigBase, dj.Lookup):
 
         @property
         def content(self):
-            return dj.U(*self.heading.secondary_attributes) & (
-                dv_nn10_scan.ScanModelInstance * dv_nn10_resp.ScanImageResponse
-            ) & (  # preblank = 5 msec
-                dv_nn10_resp.ImageResponseConfig().Lowpass() & 'pre_duration=5'
-            ) & (  # all unit & all dynamic clips
-                dv_nn10_scan.ScanConfig().Scan3() 
-                & dv_scan3_scan_dataset.UnitConfig().All()
-                & (
-                    dv_scan3_scan_dataset.TrialConfig().TrainSet() 
-                    & dv_stim2_stimulus.StimulusSetConfig().AllDynamic().proj(include_stimulus_set_hash='stimulus_set_hash')
-                    & dv_stim2_stimulus.StimulusSetConfig().OracleClip.proj(exclude_stimulus_set_hash='stimulus_set_hash')
-                )
-            )
-
-        def unit_keys(self, dynamic_scan):
-            dynamic_scan, n_units = (dv_nn10_scan.Scan & dynamic_scan & self).fetch1(
-                dj.key, "n_units")
-            units = (
-                self
-                * dv_nn10_scan.Scan.Unit
-                * dv_nn10_scan.ScanConfig().Scan3()
-                * (
-                    dv_scan3_scan_dataset.Preprocess 
-                    * dv_scan3_scan.ResponseId.proj(..., scan_ms_delay='ms_delay')
-                )  # recover spike_method
-                & dynamic_scan
-            )
-            unit_keys = units.fetch(
-                *(fuse.ScanDone * fuse.ScanSet.Unit).primary_key,
-                as_dict=True,
-                order_by="nn_response_index"
-            )
-
-            assert len(unit_keys) == n_units
-
-            return unit_keys
+            return super().content & dv_nn10_resp.ImageConfig.Vanilla
 
         def responses(self, dynamic_scan, trial_idx, condition_hashes):
             assert len(trial_idx) == len(condition_hashes)
@@ -354,50 +463,6 @@ class DvModelConfig(ConfigBase, dj.Lookup):
             assert len(cond_df) == len(resp_df)
             return np.stack(resp_df.response.values)  # (n_images, n_units)
 
-        def unique_unit_mapping(self, dynamic_scan):
-            if (
-                    self
-                    * dv_nn10_scan.ScanConfig.Scan3()
-                    * dv_scan3_scan_dataset.UnitConfig.Unique()
-                ):
-    
-                key = (
-                    (
-                        self
-                        * dv_nn10_scan.ScanConfig.Scan3()
-                        * dv_scan3_scan_dataset.UnitConfig.Unique()
-                    )
-                    & dynamic_scan
-                ).fetch1()  # get unique_id
-                unique_unit_key = (dv_scan3_scan.Unique() & dynamic_scan & key).fetch1(
-                    "KEY"
-                )
-                unique_unit_rel = (
-                    dv_scan3_scan.Unique.Unit
-                    * dv_scan3_scan.Unique.Neuron.proj(unique_unit_id="unit_id")
-                    & unique_unit_key
-                )
-                return (
-                    dj.U("animal_id", "session", "scan_idx", "unit_id", "unique_unit_id")
-                    & unique_unit_rel
-                )
-            elif (
-                    self
-                    * dv_nn10_scan.ScanConfig.Scan3()
-                    * dv_scan3_scan_dataset.UnitConfig.All()
-                ):  # return a mapping from all units to themselves
-                units = (
-                    self
-                    * dv_nn10_scan.Scan.Unit
-                    * dv_nn10_scan.ScanConfig().Scan3()
-                )
-                return units.proj(unique_unit_id='unit_id * 1')
-            else:
-                raise NotImplementedError(
-                    "`unique_unit_mapping` is not implemented for key {}!".format(
-                        self.fetch1()
-                    )
-                )
 
 @schema
 class DvScanInfo(dj.Computed):
@@ -418,11 +483,18 @@ class DvScanInfo(dj.Computed):
 
     @property
     def key_source(self):
-        keys = fuse.ScanDone * DvModelConfig
+        keys = data.StaticScan * DvModelConfig
         key = [
             # dv_nn6_models() * DvModelConfig.Nn6 * dv_nn6_scan.Scan,
             # dv_nn9_scan.ScanModelInstance * DvModelConfig.Nn9 * dv_nn9_scan.Scan,
-            dv_nn10_scan.ScanModelInstance * DvModelConfig.Nn10 * dv_nn10_scan.Scan,
+            dv_nn10_scan.ScanModelInstance
+            * DvModelConfig.Nn10
+            * dv_nn10_scan.Scan
+            ,
+            dv_nn10_scan.ScanModelInstance
+            * DvModelConfig.Nn10Frame2
+            * dv_nn10_scan.Scan
+            ,
         ]
         return keys & key
 

--- a/neuro_data/static_images/ds_pipe.py
+++ b/neuro_data/static_images/ds_pipe.py
@@ -403,18 +403,25 @@ class DvModelConfig(ConfigBase, dj.Lookup):
                     as_dict=True,
                 )
             )
-            assert len(resp_key_df) == len(cond_df)
             response = (
                 dv_nn10_scan.ScanModelInstance
                 * dv_nn10_resp.ScanImageResponse
-                * dv_nn10_resp.ImageResponseConfig.Aperture()
+                * dv_nn10_resp.ImageConfig.Aperture()
                 & dynamic_scan
                 & self
                 & resp_key_df
             )
             resp_df = pd.DataFrame(
                 (response & resp_key_df).fetch(
-                    "image_class", "image_id", "response", as_dict=True
+                    "image_class",
+                    "image_id",
+                    "aperture_x",
+                    "aperture_y",
+                    "aperture_r",
+                    "aperture_transition",
+                    "background_value",
+                    "response"
+                    , as_dict=True
                 )
             )
             resp_df = cond_df.merge(

--- a/neuro_data/static_images/requests.py
+++ b/neuro_data/static_images/requests.py
@@ -11,12 +11,14 @@ import datajoint as dj
 
 schema = dj.schema("neurodata_static")
 
+
 @schema
 class DvScanInfoRequest(dj.Manual):
     definition = """
     -> StaticScan
     -> DvModelConfig
     """
+
 
 @schema
 class DynamicStaticNoBehRequest(dj.Manual):

--- a/neuro_data/static_images/requests.py
+++ b/neuro_data/static_images/requests.py
@@ -6,11 +6,17 @@ from .dataset_config import (
     StatsConfig,
 )
 from .data_schemas import StaticScan
-from .ds_pipe import DvScanInfo
+from .ds_pipe import DvScanInfo, DvModelConfig
 import datajoint as dj
 
 schema = dj.schema("neurodata_static")
 
+@schema
+class DvScanInfoRequest(dj.Manual):
+    definition = """
+    -> StaticScan
+    -> DvModelConfig
+    """
 
 @schema
 class DynamicStaticNoBehRequest(dj.Manual):

--- a/neuro_data/utils/data.py
+++ b/neuro_data/utils/data.py
@@ -335,12 +335,21 @@ class h5cached:
 
             return data
 
-        def get_filename(oself, key=None, **kwargs):
+        def get_filename(oself, key=None, recompute=False, **kwargs):
             filename = oself._get_filename(key, **kwargs)
             if not os.path.isfile(filename):
                 print('Computing data and saving to', filename, flush=True)
                 data = oself.compute_data(key, **kwargs)
                 save_dict_to_hdf5(data, filename)
+            elif recompute:
+                delete = input(f'Delete existing cache file {filename} and recompute? (Y/n):')
+                if delete == 'Y':
+                    os.remove(filename)
+                    print('Recomputing data and saving to', filename, flush=True)
+                    data = oself.compute_data(key, **kwargs)
+                    save_dict_to_hdf5(data, filename)
+                else:
+                    print('Returning existing file', filename, flush=True)
             return filename
 
         cls.fetch1_data = fetch1_data

--- a/neuro_data/utils/stimuli.py
+++ b/neuro_data/utils/stimuli.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+
+def frame2_make_mask(x, y, r, trans, sz):  # sz is height by width
+    x, y, r, trans = float(x), float(y), float(r), float(trans)
+    if r > 1:
+        return np.ones(sz)
+    else:
+        radius = r * sz[1]
+        transition = trans * sz[1]
+        x_, y_ = x, y
+        x = np.linspace(-sz[1] / 2, sz[1] / 2, sz[1]) - x_ * sz[0]
+        y = np.linspace(-sz[0] / 2, sz[0] / 2, sz[0]) - y_ * sz[0]
+        [X, Y] = np.meshgrid(x, y)
+        rr = np.sqrt(X * X + Y * Y)
+        fxn = lambda r: 0.5 * (1 + np.cos(np.pi * r)) * (r < 1) * (r > 0) + (r < 0)
+        alpha_mask = fxn((rr - radius) / transition + 1)
+        return alpha_mask
+
+
+def frame2_apply_mask(params, frame):
+    frame_size = frame.T.shape  # frame is height by width
+    alpha_mask = frame2_make_mask(
+        params["aperture_x"],
+        params["aperture_y"],
+        params["aperture_r"],
+        params["aperture_transition"],
+        frame_size,
+    )
+    bg = params["background_value"]
+    img = (frame - bg) * alpha_mask.T + bg
+    return img


### PR DESCRIPTION
1. Implement `DvScanConfig.Nn10` to import static image responses from `dynamic_vision.nns` version 10
2. Deprecate `InputConfig.NeuroStaticFrame` due to bugs in computing statistics. Correct the computation of statistics in `StatsConfig.NoBehFullFieldFrame` by skipping the abundant input reshaping step.
3. Implement `NeuroStaticValidFrame`. Only import images that were shown during valid trials in the static scan.
4. Implement `DvScanConfig.Nn10Frame2` to import dynamic model responses to apertured static images from `dynamic_vision.nns` version 10
5. Implement `StatsConfig.NoBehFullFieldFrame2` to compute stats for `stimulus.Frame2` scans